### PR TITLE
#138: Thumbnails and previews missing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "com.github.moxy-community:moxy-ktx:2.1.2"
     kapt "com.github.moxy-community:moxy-compiler:2.1.2"
 
-    implementation 'com.github.MikeOrtiz:TouchImageView:3.1.0'
+    implementation 'com.github.MikeOrtiz:TouchImageView:3.1.1'
 
     implementation "androidx.room:room-runtime:2.3.0"
     implementation "androidx.room:room-ktx:2.3.0"

--- a/app/src/main/java/space/taran/arknavigator/mvp/model/repo/extra/ImageMetaExtra.kt
+++ b/app/src/main/java/space/taran/arknavigator/mvp/model/repo/extra/ImageMetaExtra.kt
@@ -1,6 +1,7 @@
 package space.taran.arknavigator.mvp.model.repo.extra
 
 import space.taran.arknavigator.mvp.model.repo.index.ResourceMetaExtra
+import space.taran.arknavigator.utils.extension
 import java.nio.file.Path
 
 object ImageMetaExtra {
@@ -8,4 +9,7 @@ object ImageMetaExtra {
         setOf("jpg", "jpeg", "png")
 
     fun extract(path: Path): ResourceMetaExtra? = null
+
+    fun isImage(path: Path): Boolean =
+        ACCEPTED_EXTENSIONS.contains(extension(path))
 }

--- a/app/src/main/java/space/taran/arknavigator/mvp/model/repo/index/ResourcesIndexRepo.kt
+++ b/app/src/main/java/space/taran/arknavigator/mvp/model/repo/index/ResourcesIndexRepo.kt
@@ -42,14 +42,14 @@ class ResourcesIndexRepo(
         val time1 = measureTimeMillis {
             files = listAllFiles(root)
         }
-        Log.d(RESOURCES_INDEX, "listed ${files.size} files, took $time1 milliseconds")
+        Log.d(RESOURCES_INDEX, "listed ${files.size} files in $time1 milliseconds")
 
         var metadata: Map<Path, ResourceMeta>
 
         val time2 = measureTimeMillis {
             metadata = scanResources(files)
         }
-        Log.d(RESOURCES_INDEX, "hashes calculation took $time2 milliseconds")
+        Log.d(RESOURCES_INDEX, "resources metadata retrieved in $time2 milliseconds")
 
         val index = PlainResourcesIndex(root, dao, metadata)
 

--- a/app/src/main/java/space/taran/arknavigator/mvp/model/repo/preview/PreviewGenerators.kt
+++ b/app/src/main/java/space/taran/arknavigator/mvp/model/repo/preview/PreviewGenerators.kt
@@ -1,12 +1,14 @@
 package space.taran.arknavigator.mvp.model.repo.preview
 
 import android.graphics.Bitmap
+import android.util.Log
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.request.RequestOptions
 import space.taran.arknavigator.mvp.model.repo.extra.ImageMetaExtra
 import space.taran.arknavigator.mvp.model.repo.preview.generator.PdfPreviewGenerator
 import space.taran.arknavigator.ui.App
+import space.taran.arknavigator.utils.PREVIEWS
 import space.taran.arknavigator.utils.extension
 import java.nio.file.Files
 import java.nio.file.Path
@@ -23,9 +25,9 @@ object PreviewGenerators {
     )
 
     fun generate(path: Path, previewPath: Path, thumbnailPath: Path) {
-        val ext = extension(path)
+        if (ImageMetaExtra.isImage(path)) {
+            Log.d(PREVIEWS, "$path is an image, only generating a thumbnail for it")
 
-        if (ImageMetaExtra.ACCEPTED_EXTENSIONS.contains(ext)) {
             // images are special kind of a resource:
             // we don't need to store preview file for them,
             // we only need to downscale them into thumbnail
@@ -34,7 +36,7 @@ object PreviewGenerators {
             return
         }
 
-        generatorsByExt[ext]?.let { generator ->
+        generatorsByExt[extension(path)]?.let { generator ->
             val preview = generator(path)
             val thumbnail = resizePreviewToThumbnail(preview)
             storePreview(previewPath, preview)

--- a/app/src/main/java/space/taran/arknavigator/ui/fragments/GalleryFragment.kt
+++ b/app/src/main/java/space/taran/arknavigator/ui/fragments/GalleryFragment.kt
@@ -8,6 +8,8 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.*
+import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.view.isVisible
 import androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/java/space/taran/arknavigator/utils/ImageUtils.kt
+++ b/app/src/main/java/space/taran/arknavigator/utils/ImageUtils.kt
@@ -1,6 +1,7 @@
 package space.taran.arknavigator.utils
 
 import android.graphics.drawable.Drawable
+import android.util.Log
 import android.widget.ImageView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
@@ -28,6 +29,7 @@ object ImageUtils {
     }
 
     fun loadZoomImageWithPlaceholder(image: Path?, placeHolder: Int, view: ImageView) {
+        Log.d(IMAGES, "loading image $image")
         view.setImageResource(placeHolder)
         view.autoDisposeScope.launch {
             withContext(Dispatchers.Main) {
@@ -51,6 +53,7 @@ object ImageUtils {
     }
 
     fun loadImageWithPlaceholder(image: Path?, placeHolder: Int, view: ImageView) {
+        Log.d(IMAGES, "loading image $image")
         view.setImageResource(placeHolder)
         view.autoDisposeScope.launch {
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/space/taran/arknavigator/utils/ImageUtils.kt
+++ b/app/src/main/java/space/taran/arknavigator/utils/ImageUtils.kt
@@ -4,8 +4,12 @@ import android.graphics.drawable.Drawable
 import android.util.Log
 import android.widget.ImageView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.target.Target
 import com.bumptech.glide.request.transition.Transition
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -54,7 +58,6 @@ object ImageUtils {
 
     fun loadImageWithPlaceholder(image: Path?, placeHolder: Int, view: ImageView) {
         Log.d(IMAGES, "loading image $image")
-        view.setImageResource(placeHolder)
         view.autoDisposeScope.launch {
             withContext(Dispatchers.Main) {
                 Glide.with(view)
@@ -64,5 +67,24 @@ object ImageUtils {
                     .into(view)
             }
         }
+    }
+
+    fun <T> glideExceptionListener() = object: RequestListener<T>{
+        override fun onLoadFailed(
+            e: GlideException?,
+            model: Any?,
+            target: Target<T>?,
+            isFirstResource: Boolean
+        ): Boolean {
+            Log.d(GLIDE, "load failed with message: ${e?.message} for target of type: ${target?.javaClass?.canonicalName}")
+            return true
+        }
+
+        override fun onResourceReady(
+            resource: T,
+            model: Any?,
+            target: Target<T>?,
+            dataSource: DataSource?,
+            isFirstResource: Boolean) = false
     }
 }

--- a/app/src/main/java/space/taran/arknavigator/utils/LogTags.kt
+++ b/app/src/main/java/space/taran/arknavigator/utils/LogTags.kt
@@ -27,8 +27,8 @@ const val TAGS_STORAGE: String = "tags-storage"
 
 const val ITEMS_CONTAINER: String = "item-container"
 
-const val CONCURRENT: String = "concurrent"
-
 const val DATABASE: String = "database"
 
 const val PREVIEWS: String = "previews"
+
+const val IMAGES: String = "images"

--- a/app/src/main/java/space/taran/arknavigator/utils/LogTags.kt
+++ b/app/src/main/java/space/taran/arknavigator/utils/LogTags.kt
@@ -32,3 +32,5 @@ const val DATABASE: String = "database"
 const val PREVIEWS: String = "previews"
 
 const val IMAGES: String = "images"
+
+const val GLIDE: String = "glide"


### PR DESCRIPTION
Before, we were generating previews only for added resources and assuming later that all indexed resources already have at least thumbnails (images don't have previews, only thumbnails).

Now, we check all existing resources for having previews/thumbnails generated.
If there is a thumbnail for a resource already, nothing happens.
If there is no such, new preview and thumbnails generated.

Also, time measurements with writing the results into log added.

**Help needed:** it is a good idea to handle exceptions coming from preview/thumbnail generation since they are failing whole coroutine and the rest of resources don't get their previews even if we could continue.
See `//todo: handle exceptions to not fail the rest of previews generation`