### PR TITLE
Feature/Rust lib crc32 compute_id

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Build and Test the Rust library
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Build
+        run: cd arklib && cargo build --lib --verbose
+      - name: Test
+        run: cd arklib && cargo test --lib --verbose
+

--- a/arklib/.gitignore
+++ b/arklib/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/arklib/Cargo.toml
+++ b/arklib/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "arklib"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/arklib/Cargo.toml
+++ b/arklib/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.14"
+crc32fast = "1.3.0"
+env_logger = "0.9.0"

--- a/arklib/src/lib.rs
+++ b/arklib/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/arklib/src/lib.rs
+++ b/arklib/src/lib.rs
@@ -5,6 +5,7 @@ mod utils {
     use std::io::{BufReader, BufRead};
     use crc32fast::Hasher;
     
+    #[allow(dead_code)]
     pub fn compute_id<PathRef: AsRef<Path>>(size: usize, file: &PathRef) -> u32 {
         const KILOBYTE: usize = 1024;
         const MEGABYTE: usize = 1024 * KILOBYTE;

--- a/arklib/src/lib.rs
+++ b/arklib/src/lib.rs
@@ -1,8 +1,53 @@
+mod utils {
+    
+    use std::fs;
+    use std::path::Path;
+    use std::io::{BufReader, BufRead};
+    use crc32fast::Hasher;
+    
+    pub fn compute_id<PathRef: AsRef<Path>>(size: usize, file: &PathRef) -> u32 {
+        const KILOBYTE: usize = 1024;
+        const MEGABYTE: usize = 1024 * KILOBYTE;
+        const BUFFER_CAPACITY: usize = 512 * KILOBYTE;
+        println!("calculating hash of {} (size is {} megabytes)", file.as_ref().display(), size / MEGABYTE);
+        let source = fs::OpenOptions::new()
+            .read(true)
+            .open(file)
+            .expect(&format!("Failed to read from {}", file.as_ref().display()));
+        let mut reader = BufReader::with_capacity(BUFFER_CAPACITY, source);
+        assert!(reader.buffer().is_empty());
+        let mut hasher = Hasher::new();
+        let mut bytes_read: usize = 0;
+        loop {
+            let bytes_read_iteration = reader
+                .fill_buf()
+                .expect(&format!("Failed to read from {}", file.as_ref().display()))
+                .len();
+            if bytes_read_iteration == 0 {
+                break;
+            }
+            hasher.update(reader.buffer());
+            reader.consume(bytes_read_iteration);
+            bytes_read += bytes_read_iteration;
+        }
+        let checksum: u32 = hasher.finalize();
+        println!("{} bytes has been read", bytes_read);
+        assert!(bytes_read == size);
+        return checksum;
+    }
+
 #[cfg(test)]
-mod tests {
     #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+    fn check_crc32() {
+        const INPUT_FILE_NAME: &'static str = "assets/crc32_sample_file.bin";
+        let input_file_path = Path::new(INPUT_FILE_NAME);
+        let input_file_metadata = fs::metadata(INPUT_FILE_NAME)
+            .expect(&format!("Failed to read metadata from from {}", input_file_path.display()));
+        let input_file_size = usize::try_from(input_file_metadata.len())
+                .expect(&format!("Unknown file size {}", input_file_path.display()));
+        let file_checksum: u32 = compute_id(
+            input_file_size,
+            &input_file_path);
+        assert_eq!(0xae614f37, file_checksum);
     }
 }


### PR DESCRIPTION
Solves https://github.com/ARK-Builders/ARK-Navigator/issues/179 through [Gitcoin](https://gitcoin.co/issue/ark-builders/ark-navigator/179/100027426).

A _Rust_-based solution has been developed to perform the `computeId` function as described in [`app/src/main/java/space/taran/arknavigator/mvp/model/repo/index/ResourceId.kt` ](https://github.com/ARK-Builders/ARK-Navigator/blob/56df708a520e34bea2895c7e6dd2eeeefe928747/app/src/main/java/space/taran/arknavigator/mvp/model/repo/index/ResourceId.kt). This _Rust_ library defined function (`compute_id` following _Rust_ naming conventions) takes into account the same assertions and print the same messages as the _Kotlin_ previous one.

Added to the aforementioned, the library build and testing processes have been added as a _Github Actions_ workflow by using the latest _Rust_ stable release. This workflow has been tested locally by using [_Act_](https://github.com/nektos/act) but cache functionality should be tested online.

Please, could you check the functionality is implemented as expected?