### PR TITLE
Case insensitive sorting

### DIFF
--- a/app/src/main/java/space/taran/arknavigator/utils/FileUtils.kt
+++ b/app/src/main/java/space/taran/arknavigator/utils/FileUtils.kt
@@ -75,7 +75,7 @@ fun extension(path: Path): String {
 
 fun reifySorting(sorting: Sorting): Comparator<ResourceMeta>? =
     when (sorting) {
-        Sorting.NAME -> compareBy { it.name }
+        Sorting.NAME -> compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }
         Sorting.SIZE -> compareBy { it.size }
         Sorting.TYPE -> compareBy { it.extension }
         Sorting.LAST_MODIFIED -> compareBy { it.modified }


### PR DESCRIPTION
Solves #200.

A new comparator behavior has been integrated so we could sort in a case insensitive order.
