### PR TITLE
StorageBackup ZipExcepton: No entries fix

### DIFF
--- a/app/src/main/java/space/taran/arknavigator/mvp/model/backup/StorageBackup.kt
+++ b/app/src/main/java/space/taran/arknavigator/mvp/model/backup/StorageBackup.kt
@@ -54,11 +54,12 @@ class StorageBackup @Inject constructor(
         val filesToBackup = listOf(
             arkPath.resolve(ArkFiles.FAVORITES_FILE),
             arkPath.resolve(ArkFiles.TAGS_STORAGE_FILE)
-        )
+        ).filter { it.exists() }
+
+        if (filesToBackup.isEmpty()) return
 
         ZipOutputStream(backupPath.outputStream()).use { zipOut ->
             filesToBackup
-                .filter { it.exists() }
                 .forEach { backupFile ->
                     val zipEntry = ZipEntry(backupFile.fileName.toString())
                     zipOut.putNextEntry(zipEntry)


### PR DESCRIPTION
```
java.util.zip.ZipException: No entries
	at java.util.zip.ZipOutputStream.finish(ZipOutputStream.java:363)
	at java.util.zip.DeflaterOutputStream.close(DeflaterOutputStream.java:239)
	at java.util.zip.ZipOutputStream.close(ZipOutputStream.java:383)
	at kotlin.io.CloseableKt.closeFinally(Closeable.kt:57)
	at space.taran.arknavigator.mvp.model.backup.StorageBackup.backupRoot(StorageBackup.kt:59)
	at space.taran.arknavigator.mvp.model.backup.StorageBackup.access$backupRoot(StorageBackup.kt:26)
	at space.taran.arknavigator.mvp.model.backup.StorageBackup$backup$1.invokeSuspend(StorageBackup.kt:41)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.UndispatchedCoroutine.afterResume(CoroutineContext.kt:161)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:106)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.UndispatchedCoroutine.afterResume(CoroutineContext.kt:161)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:106)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:39)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```