### PR TITLE
Scores npe fix

### DIFF
--- a/app/src/main/java/space/taran/arknavigator/mvp/model/repo/scores/PlainScoreStorage.kt
+++ b/app/src/main/java/space/taran/arknavigator/mvp/model/repo/scores/PlainScoreStorage.kt
@@ -9,7 +9,6 @@ import space.taran.arknavigator.mvp.model.repo.index.ResourceId
 import space.taran.arknavigator.mvp.model.repo.index.ResourceMeta
 import space.taran.arknavigator.utils.LogTags.SCORES_STORAGE
 import space.taran.arknavigator.utils.Score
-import java.lang.AssertionError
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
@@ -49,19 +48,14 @@ class PlainScoreStorage(
         scoreById = result
     }
 
-    fun refresh(resources: Collection<ResourceId>) = run {
+    fun refresh(resources: Collection<ResourceId>) {
         Log.d(
             SCORES_STORAGE,
             "refreshing score storage with new and edited resources"
         )
-        val scoreById = this.scoreById
-        this.scoreById = resources.associateWith {
-            0
-        }.toMutableMap()
         resources.forEach { id ->
-            this.scoreById[id] = scoreById[id]!!
+            scoreById.computeIfAbsent(id) { 0 }
         }
-
         Log.d(
             SCORES_STORAGE,
             "${this.scoreById.size} resources available in score storage"
@@ -81,8 +75,7 @@ class PlainScoreStorage(
         scoreById[id] = score
     }
 
-    override fun getScore(id: ResourceId) =
-        scoreById.getOrDefault(id, 0)
+    override fun getScore(id: ResourceId) = scoreById[id]!!
 
     override suspend fun persist() =
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
```
java.lang.NullPointerException
	at space.taran.arknavigator.mvp.model.repo.scores.PlainScoreStorage.refresh(PlainScoreStorage.kt:62)
	at space.taran.arknavigator.mvp.model.repo.scores.ScoreStorageRepo$provide$2.invokeSuspend(ScoreStorageRepo.kt:28)
	at space.taran.arknavigator.mvp.model.repo.scores.ScoreStorageRepo$provide$2.invoke(Unknown Source:8)
	at space.taran.arknavigator.mvp.model.repo.scores.ScoreStorageRepo$provide$2.invoke(Unknown Source:4)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
	at space.taran.arknavigator.mvp.model.repo.scores.ScoreStorageRepo.provide(ScoreStorageRepo.kt:20)
	at space.taran.arknavigator.mvp.presenter.GalleryPresenter$onEditedResourceDetected$2.invokeSuspend(GalleryPresenter.kt:318)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:39)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

