### PR TITLE
Follow-up to #342

### DIFF
--- a/app/src/main/res/layout/fragment_resources.xml
+++ b/app/src/main/res/layout/fragment_resources.xml
@@ -37,46 +37,42 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/scores_tv"
+            android:id="@+id/switch_scores_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/scores"
+            android:text="Kind"
             android:textStyle="bold"
-            android:layout_marginStart="4dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/sw_scores"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/switch_scores"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <space.taran.arknavigator.ui.view.UserSwitchMaterial
-            android:id="@+id/sw_scores"
+            android:id="@+id/switch_scores"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="42dp"
-            app:layout_constraintStart_toStartOf="@id/scores_tv"
+            app:layout_constraintStart_toStartOf="@id/switch_scores_tv"
+            app:layout_constraintEnd_toEndOf="@id/switch_kind_tv"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/switch_kind_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Kind"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@id/switch_scores"
+            app:layout_constraintEnd_toStartOf="@id/switch_kind"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <space.taran.arknavigator.ui.view.UserSwitchMaterial
             android:id="@+id/switch_kind"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="@id/switch_kind_tv"
             app:layout_constraintEnd_toEndOf="@id/iv_drag_handler"
-            app:layout_constraintHorizontal_bias="0.795"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/switch_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Kind"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/switch_kind"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toStartOf="@id/sw_scores"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.448" />
 
         <ImageView
             android:id="@+id/iv_drag_handler"


### PR DESCRIPTION
"Scores" label near the switch is shifted, so only "cores" part is visible.

Affected device:
Samsung Galaxy Note 10+
LineageOS
Android 12