### PR TITLE
Support static code anslysis with githook and local lint check

### DIFF
--- a/app/app-scripts/pre-commit
+++ b/app/app-scripts/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo "*********************************************************"
+echo "Running git pre-commit hook, ktlintCheck in progress..."
+echo "*********************************************************"
+
+./gradlew ktlintCheck
+
+status=$?
+
+if [ "$status" = 0 ] ; then
+    echo "Static analysis found no problems."
+    exit 0
+else
+    echo "*********************************************************"
+    echo 1>&2 "ktlintCheck found violations it could not fix."
+    echo "Run ./gradlew ktlintFormat to fix formatting related issues..."
+    echo "*********************************************************"
+    exit 1
+fi

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,3 +198,5 @@ tasks.register('installGitHook', Copy) {
     rename("pre-commit-$suffix", 'pre-commit')
     fileMode 0775
 }
+
+build.dependsOn installGitHook


### PR DESCRIPTION
## :rocket: Summary
- Run `ktlintCheck` on every commit using git hooks.
- Support running `ktlinCheck` locally by triggering it before every `./gradlew build` or `./gradlew check` command for local lint analysis.

Related issues: 
https://github.com/ARK-Builders/ARK-Navigator/issues/409
https://github.com/ARK-Builders/ARK-Navigator/issues/402