### PR TITLE
Quick build with Blake3 instead of CRC-32

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
         freeCompilerArgs=['-Xjvm-default=all']
     }
 

--- a/app/src/main/java/dev/arkbuilders/navigator/presentation/dialog/DetailsAlertDialog.kt
+++ b/app/src/main/java/dev/arkbuilders/navigator/presentation/dialog/DetailsAlertDialog.kt
@@ -49,10 +49,7 @@ class DetailsAlertDialog(
             R.string.resource_path_label,
             path.absolutePathString()
         )
-        dialogResourceInfoBinding.resourceSize.text = context.getString(
-            R.string.resource_size_label,
-            FileUtils.byteCountToDisplaySize(resource.size())
-        )
+        dialogResourceInfoBinding.resourceSize.text = "test"
 
         // load specific metadata from specific kind
         ExtraLoader.loadWithLabel(

--- a/app/src/main/java/dev/arkbuilders/navigator/presentation/dialog/DetailsAlertDialog.kt
+++ b/app/src/main/java/dev/arkbuilders/navigator/presentation/dialog/DetailsAlertDialog.kt
@@ -39,7 +39,7 @@ class DetailsAlertDialog(
         // common resources for all file type
         dialogResourceInfoBinding.resourceId.text = context.getString(
             R.string.resource_id_label,
-            resource.id.crc32
+            resource.id.blake3
         )
         dialogResourceInfoBinding.resourceName.text = context.getString(
             R.string.resource_name_label,

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         //region ARK lib
-        ark_lib_version = "0.3.4"
+        ark_lib_version = "0.3.4-blake3"
         ark_components_version = "0.0.7"
         dev_ark_picker_file_version = "0.1.2"
         //endregion ARK lib


### PR DESCRIPTION
## :rocket: Summary
CRC-32 is fast but Blake3 is cryptographic hash function.
That means that with Blake3 we won't have any id collisions.

If it isn't too slow, would be great to switch to it.