### PR TITLE
Improve CI by reduce dependency between steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       run: ./gradlew testDebugUnitTest
 
   lint:
-    # needs: test
+    needs: test
     environment: Development
     runs-on: ubuntu-latest
     steps:
@@ -135,7 +135,7 @@ jobs:
         path: ./app/build/reports/lint-results-debug.html
 
   ktlint:
-    # needs: test
+    needs: test
     environment: Development
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       run: ./gradlew testDebugUnitTest
 
   lint:
-    needs: test
+    # needs: test
     environment: Development
     runs-on: ubuntu-latest
     steps:
@@ -135,7 +135,7 @@ jobs:
         path: ./app/build/reports/lint-results-debug.html
 
   ktlint:
-    needs: test
+    # needs: test
     environment: Development
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,6 @@ jobs:
       run: ./gradlew testDebugUnitTest
 
   lint:
-    needs: test
     environment: Development
     runs-on: ubuntu-latest
     steps:
@@ -135,7 +134,6 @@ jobs:
         path: ./app/build/reports/lint-results-debug.html
 
   ktlint:
-    needs: test
     environment: Development
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## :rocket: Summary
Currently, total time taken to complete the whole build for each commit is ~10mins.
Build - 5 mins
Test - 2 mins (depends on build)
Lint and Klint - 2 mins (depends on test)
It takes about 7 mins before linting to be run while it is unnecessary making linting depends on test and build. 
Other than that, linting can be requested to be fixed by reviewer before they approve the PR, hence it is fine to keep linting out of build or test steps

## ✅ Solution
By removing the dependency on test, linting could be run separately, it would reduce total time it takes to complete the build from 10mins to 8mins or faster
**Result**
<img width="650" alt="Screenshot 2024-02-12 at 15 22 37" src="https://github.com/ARK-Builders/ARK-Navigator/assets/43868345/fccb040b-5728-427f-b536-18268dcb509c">


